### PR TITLE
Switch to androidx SubsamplingScaleImageView dep

### DIFF
--- a/matisse/build.gradle
+++ b/matisse/build.gradle
@@ -42,7 +42,7 @@ dependencies {
     implementation "androidx.annotation:annotation:1.1.0"
     implementation "androidx.recyclerview:recyclerview:1.1.0"
     implementation 'it.sephiroth.android.library.imagezoom:library:1.0.4'
-    implementation("com.davemorrissey.labs:subsampling-scale-image-view:3.10.0")
+    implementation("com.davemorrissey.labs:subsampling-scale-image-view-androidx:3.10.0")
     compileOnly 'com.github.bumptech.glide:glide:4.11.0'
     compileOnly 'com.squareup.picasso:picasso:2.5.2'
 }


### PR DESCRIPTION
As you're using androidx for the main lib, it's probably worth using the androidx version of the SubsamplingScaleImageView. We've disabled the jetifier and with the currently included dependency we can't include this version of the library